### PR TITLE
Auth must be called before Select

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -349,8 +349,8 @@ func newConn(netTyp, addr string, db int, password string) (*conn, error) {
 }
 
 func (cc *conn) configConn(db int, password string) error {
-    if db != 0 {
-        buf := [][]byte{[]byte("SELECT"), []byte(strconv.Itoa(db))}
+    if password != "" {
+        buf := [][]byte{[]byte("AUTH"), []byte(password)}
         _, err := cc.rwc.Write(buildCmd(buf))
 
         if err != nil {
@@ -363,8 +363,8 @@ func (cc *conn) configConn(db int, password string) error {
         }
     }
 
-    if password != "" {
-        buf := [][]byte{[]byte("AUTH"), []byte(password)}
+    if db != 0 {
+        buf := [][]byte{[]byte("SELECT"), []byte(strconv.Itoa(db))}
         _, err := cc.rwc.Write(buildCmd(buf))
 
         if err != nil {


### PR DESCRIPTION
When I try to connect to database != 0 with authentication. I must call Auth command before Select command.

Simple code that should work after my change:

---- begin of test.go ----
package main

import (
    "godis"
)

func main() {
    db := godis.New("", 1, "secret")

```
foo, err := db.Get("foo")
if err == nil {
    println(foo.String())
} else {
    println(err.String())
}
```

}
---- end of test.go ----
