### PR TITLE
MULTI..EXEC transactions and asynchronous Call commands

### DIFF
--- a/exp/godis.go
+++ b/exp/godis.go
@@ -145,10 +145,10 @@ func NewAsyncClient(addr string, db int, password string) *AsyncClient {
 }
 
 // Call appends a command to the write buffer or returns an error.
-func (ac *AsyncClient) Call(args ...interface{}) (err error) {
-    _, err = ac.buf.Write(format(args...))
+func (ac *AsyncClient) Call(args ...interface{}) {
+	// note: bytes.Buffer.Write never returns an error
+    _, _ = ac.buf.Write(format(args...))
     ac.queued++
-    return err
 }
 
 // Read does three things. 

--- a/exp/parse.go
+++ b/exp/parse.go
@@ -12,6 +12,10 @@ import (
 var (
     debug       = false
     ErrProtocol = errors.New("godis: protocol error")
+
+    // the err returned by ReadAll when a MULTI..EXEC is aborted due to
+    // a WATCH condition
+    ErrMultiAborted = errors.New("-MULTI-BULK: nil reply")
 )
 
 func (r *Reply) parseErr(res []byte) {
@@ -83,7 +87,7 @@ func (r *Reply) parseMultiBulk(buf *bufin.Reader, res []byte) {
     l, _ := strconv.Atoi(string(res))
 
     if l == -1 {
-        r.Err = errors.New("-MULTI-BULK: nil reply")
+        r.Err = ErrMultiAborted
         return
     }
 


### PR DESCRIPTION
Hi,

This pull request addresses three issues:
1. When a MULTI..EXEC transaction fails because of a WATCH condition, an error is returned by ReadAll.  It is difficult to test this error to see if it was due to an aborted transaction or something else.  I have named the error as ErrMultiAborted, so now you can just do a check like so:
   
   if err == redis.ErrMultiAborted { // transaction aborted, try again
2. The Call method of an AsyncClient cannot return any errors, so I removed the err return value.  It calls Write in bytes.Buffer, but the docs for that method explicitly say it will never return an err (it just has the return type to match the io.Writer interface).  Removing this lets careful people know it is okay to assume the call will succeed.
3. When using WATCH with MULTI..EXEC transactions, the normal pattern is:
   
   WATCH foo
   GET foo
   MULTI
   do stuff using the value of foo that is now guaranteed to not change
   EXEC

AsyncClient handles the MULTI..EXEC part great, but it is a bit verbose to run the commands that happen before the MULTI is issued.  This adds a SyncCall to AsyncClient that works more like Call from Client.  It fails if there are already commands in the queue.

Thanks,

Russ
